### PR TITLE
Update edit_screen.php

### DIFF
--- a/modules/downloads/includes/fileControl/edit_screen.php
+++ b/modules/downloads/includes/fileControl/edit_screen.php
@@ -71,10 +71,10 @@ if ($request->getMethod() === 'POST') {
     if (! empty($files) && ! empty($files['screen'])) {
         /** @var GuzzleHttp\Psr7\UploadedFile $screen */
         $screen = $files['screen'] ?? false;
-        $file_name = $dir . '/' . $id . '.png';
-        if (file_exists($file_name)) {
+        /*$file_name = $dir . '/' . $id . '.png';
+        if (file_exists($file_name)) {*/
             $file_name = $dir . '/' . time() . '_' . $id . '.png';
-        }
+        //}
         // Пытаемся обработать файл и сохранить его
         try {
             /** @var ImageManager $image_manager */


### PR DESCRIPTION
Завжди додавати unixtime до назви знімків для правильного сортування (порядок розташування) та кешування (оглядач і CF можуть зберегти стару версію на деякий час, якщо не змінювати назву)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Прибрав непотрібну перевірку на існування файлу з іменем за ідентифікатором завантаження, бо у цьому нема сенсу, коли всі файли знімків містять час додавання у назві

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Виправляє проблему порядку розташування знімків і оновлення кешу
https://trello.com/c/HHU9m29F/52-назва-файлів-знімків-за-unixtime-для-правильного-сортування-порядок-розташування-та-кешування-оглядач-і-cf-можуть-зберегти-стару

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Не перевіряв, але це простіша зміна коду, яка не має зламати нічого, бо задіяна лише одна і та сама змінна

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run `composer check` locally, and there were no failures or errors.
